### PR TITLE
Check if field can be nil before calling IsNil()

### DIFF
--- a/render.go
+++ b/render.go
@@ -44,6 +44,15 @@ func RenderList(w http.ResponseWriter, r *http.Request, l []Renderer) error {
 	return nil
 }
 
+func isNil(f reflect.Value) bool {
+	switch f.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return f.IsNil()
+	default:
+		return false
+	}
+}
+
 // Executed top-down
 func renderer(w http.ResponseWriter, r *http.Request, v Renderer) error {
 	rv := reflect.ValueOf(v)
@@ -66,7 +75,7 @@ func renderer(w http.ResponseWriter, r *http.Request, v Renderer) error {
 		f := rv.Field(i)
 		if f.Type().Implements(rendererType) {
 
-			if f.IsNil() {
+			if isNil(f) {
 				continue
 			}
 
@@ -98,7 +107,7 @@ func binder(r *http.Request, v Binder) error {
 		f := rv.Field(i)
 		if f.Type().Implements(binderType) {
 
-			if f.IsNil() {
+			if isNil(f) {
 				continue
 			}
 


### PR DESCRIPTION
`f.IsNil` would panic if called on a Value with a non-nilable kind, e.g. a struct

To reproduce, try rendering (or binding) a struct whose field is a struct and implements `Renderer` or `Binder`, respectively. 

Obviously, the primitive types cannot implement `rendererType`, so they don't face this problem.