### PR TITLE
Fixed RFC7540 (HTTP2) combatiliby

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -146,7 +146,13 @@ func channelEventStream(w http.ResponseWriter, r *http.Request, v interface{}) {
 
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+
+	if r.ProtoMajor == 1 {
+		// An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields.
+		// Source: RFC7540
+		w.Header().Set("Connection", "keep-alive")
+	}
+
 	w.WriteHeader(200)
 
 	ctx := r.Context()


### PR DESCRIPTION
As mentioned in [RFC7540](https://tools.ietf.org/html/rfc7540#section-8.1.2.2) HTTP2 responses should not return "connection" header.

This may cause some problems with curl for example:
```
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
* http2 error: Invalid HTTP header field was received: frame type: 1, stream: 1, name: [connection], value: [keep-alive]
* HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
* Closing connection 0
* TLSv1.2 (OUT), TLS alert, Client hello (1):
curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
```

I'd also noticed problems with mobile browsers (Safari, Chrome on iOS).