### PR TITLE
Update responder.go

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -135,7 +135,7 @@ func XML(w http.ResponseWriter, r *http.Request, v interface{}) {
 }
 
 // NoContent returns a HTTP 204 "No Content" response.
-func NoContent(w http.ResponseWriter, r *http.Request) {
+func NoContent(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(204)
 }
 


### PR DESCRIPTION
Update method `NoContent` to be explicit about the fact that it does not use the `http.Request`.
Use [_](https://golang.org/doc/effective_go.html#blank) instead of a named variable