### PR TITLE
Add option to output unescaped HTML in JSON strings

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -88,12 +88,23 @@ func HTML(w http.ResponseWriter, r *http.Request, v string) {
 	w.Write([]byte(v))
 }
 
-// JSON marshals 'v' to JSON, automatically escaping HTML and setting the
-// Content-Type as application/json.
-func JSON(w http.ResponseWriter, r *http.Request, v interface{}) {
+// JSONEncoderOpt is a function that can set options on the JSON encoder.
+type JSONEncoderOpt func(*json.Encoder)
+
+// UnescapedHTML disables escaping of &, < and > in JSON strings.
+func UnescapedHTML(enc *json.Encoder) {
+	enc.SetEscapeHTML(false)
+}
+
+// JSON marshals 'v' to JSON, automatically escaping HTML by default,
+// and setting the Content-Type as application/json.
+func JSON(w http.ResponseWriter, r *http.Request, v interface{}, opts ...JSONEncoderOpt) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(true)
+	for _, opt := range opts {
+		opt(enc)
+	}
+
 	if err := enc.Encode(v); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This can be useful for example when outputting a URL in a JSON value,
which contains a query string, where the ampersands & should remain intact.