### PR TITLE
Optional Binder

### DIFF
--- a/render.go
+++ b/render.go
@@ -15,13 +15,18 @@ type Binder interface {
 	Bind(r *http.Request) error
 }
 
-// Bind decodes a request body and executes the Binder method of the
-// payload structure.
-func Bind(r *http.Request, v Binder) error {
+// Bind decodes a request body.
+// If the payload implements Binder interface, Bind method is called.
+func Bind(r *http.Request, v interface{}) error {
 	if err := Decode(r, v); err != nil {
 		return err
 	}
-	return binder(r, v)
+
+	if b, ok := v.(Binder); ok {
+		return binder(r, b)
+	}
+
+	return nil
 }
 
 // Render renders a single payload and respond to the client request.


### PR DESCRIPTION
In many cases you just need to decode the payload without any post-actions. In this update Bind() method is called only if the payload implements the Binder interface.