### PR TITLE
Add strict option to DecodeJSON

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -39,9 +39,16 @@ func DefaultDecoder(r *http.Request, v interface{}) error {
 }
 
 // DecodeJSON decodes a given reader into an interface using the json decoder.
-func DecodeJSON(r io.Reader, v interface{}) error {
+// Strict is used to call DisallowUnknownFields on the decoder and is false
+// by default
+func DecodeJSON(r io.Reader, v interface{}, strict ...bool) error {
 	defer io.Copy(ioutil.Discard, r) //nolint:errcheck
-	return json.NewDecoder(r).Decode(v)
+	dec := json.NewDecoder(r)
+	// Check if strict is set and is true
+	if len(strict) > 0 && strict[0] {
+		dec.DisallowUnknownFields()
+	}
+	return dec.Decode(v)
 }
 
 // DecodeXML decodes a given reader into an interface using the xml decoder.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,0 +1,42 @@
+package render
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+type example struct {
+	Field string `json:"field"`
+}
+
+func createTestInput() io.Reader {
+	return bytes.NewBuffer([]byte(`{"field":"some input","unknown":null}`))
+}
+
+func TestStrictDecoder(t *testing.T) {
+	ex := &example{}
+
+	t.Run("strict", func(t *testing.T) {
+		// Test strict
+		buf := createTestInput()
+		err := DecodeJSON(buf, ex, true)
+		// Could not find a custom error type for disallowed fields
+		// https://github.com/golang/go/issues/40982
+		if !strings.Contains(err.Error(), "unknown field") || err == nil {
+			t.Errorf("should return error and contain 'unkown field'\n")
+		}
+	})
+
+	t.Run("relaxed", func(t *testing.T) {
+		// Test relaxed
+		buf := createTestInput()
+		err := DecodeJSON(buf, ex)
+		// Make sure strict is false by default
+		if err != nil {
+			t.Errorf("should not return error: %v\n", err)
+		}
+	})
+
+}


### PR DESCRIPTION
Adds a strict option to the DecodeJSON function to call the DisallowUnknownFields on the json decoder, returning an error if the json payload contains unknown fields.