### PR TITLE
Add encoder/decoder interface to configure encoding/decoding

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -14,6 +14,7 @@ import (
 // Decoder is a generic interface to decode arbitrary data from a reader `r` to
 // a value `v`.
 type Decoder interface {
+	// Decodes a given reader into an interface
 	Decode(r io.Reader, req *http.Request, v interface{}) error
 }
 
@@ -55,7 +56,7 @@ func DefaultDecoder(r *http.Request, v interface{}) error {
 
 type DecodeJSONInter struct{}
 
-// DecodeJSON decodes a given reader into an interface using the json decoder.
+// Decodes a given reader into an interface using the json decoder.
 func (DecodeJSONInter) Decode(r io.Reader, req *http.Request, v interface{}) error {
 	defer io.Copy(ioutil.Discard, r) //nolint:errcheck
 	return json.NewDecoder(r).Decode(v)
@@ -71,7 +72,7 @@ func DecodeJSON(r io.Reader, v interface{}) error {
 
 type DecodeXMLInter struct{}
 
-// DecodeXML decodes a given reader into an interface using the xml decoder.
+// Decodes a given reader into an interface using the xml decoder.
 func (DecodeXMLInter) Decode(r io.Reader, req *http.Request, v interface{}) error {
 	defer io.Copy(ioutil.Discard, r) //nolint:errcheck
 	return xml.NewDecoder(r).Decode(v)
@@ -87,7 +88,7 @@ func DecodeXML(r io.Reader, v interface{}) error {
 
 type DecodeFormInter struct{}
 
-// DecodeForm decodes a given reader into an interface using the form decoder.
+// Decodes a given reader into an interface using the form decoder.
 func (DecodeFormInter) Decode(r io.Reader, req *http.Request, v interface{}) error {
 	decoder := form.NewDecoder(r) //nolint:errcheck
 	return decoder.Decode(v)

--- a/responder.go
+++ b/responder.go
@@ -16,6 +16,7 @@ var ErrInvalidType error = errors.New("Invalid Type passed")
 // Encoder is a generic interface to encode arbitrary data from value `v`  to a
 // reader `r`
 type Encoder interface {
+	// Marshals 'v' to 'w'
 	Encode(w http.ResponseWriter, req *http.Request, v interface{}) error
 }
 
@@ -83,7 +84,7 @@ func DefaultResponder(w http.ResponseWriter, r *http.Request, v interface{}) {
 
 type EncodePlainText struct{}
 
-// PlainText writes a string to the response, setting the Content-Type as
+// Writes a string to the response, setting the Content-Type as
 // text/plain.
 // vi has to be string
 func (EncodePlainText) Encode(w http.ResponseWriter, r *http.Request, vi interface{}) error {
@@ -113,7 +114,7 @@ func PlainText(w http.ResponseWriter, r *http.Request, v string) {
 
 type EncodeData struct{}
 
-// Data writes raw bytes to the response, setting the Content-Type as
+// Writes raw bytes to the response, setting the Content-Type as
 // application/octet-stream.
 // vi has to be []byte
 func (EncodeData) Encode(w http.ResponseWriter, r *http.Request, vi interface{}) error {
@@ -143,7 +144,7 @@ func Data(w http.ResponseWriter, r *http.Request, v []byte) {
 
 type EncodeHTML struct{}
 
-// HTML writes a string to the response, setting the Content-Type as text/html.
+// Writes a string to the response, setting the Content-Type as text/html.
 // vi has to be a string.
 func (EncodeHTML) Encode(w http.ResponseWriter, r *http.Request, vi interface{}) error {
 	v, ok := vi.(string)
@@ -171,7 +172,7 @@ func HTML(w http.ResponseWriter, r *http.Request, v string) {
 
 type EncodeJSON struct{}
 
-// JSON marshals 'v' to JSON, automatically escaping HTML and setting the
+// Marshals 'v' to JSON, automatically escaping HTML and setting the
 // Content-Type as application/json.
 func (EncodeJSON) Encode(w http.ResponseWriter, r *http.Request, v interface{}) error {
 	buf := &bytes.Buffer{}
@@ -213,7 +214,7 @@ func JSON(w http.ResponseWriter, r *http.Request, v interface{}) {
 
 type EncodeXML struct{}
 
-// XML marshals 'v' to XML, setting the Content-Type as application/xml. It
+// Marshals 'v' to XML, setting the Content-Type as application/xml. It
 // will automatically prepend a generic XML header (see encoding/xml.Header) if
 // one is not found in the first 100 bytes of 'v'.
 func (EncodeXML) Encode(w http.ResponseWriter, r *http.Request, v interface{}) error {


### PR DESCRIPTION
Like discussed in #40 . There are still things to do:
- [x] document the interface/variables properly
- [x] Backwards compatibility
- [ ] Not quite satisfied with `Decoder` as name for the interface in the `decoder.go` file where actually `Decode` is the core component (with `Encoder` this is much better as there the term `responder` is being used)

On the second point: As `DecodeJSON` etc were public functions, to be fully backwards compatible, they need to be preserved, right? So maybe the best shot is to keep those functions and in the default implementation of `Decoder`/`Encoder` for e.g. `JSON` just delegate the calls to these old functions, right?

---
As this is not finished yet, it's just a draft PR. Nevertheless I already stated TODOs so if you already have any comment on the current state, don't hesitate.