### PR TITLE
add charset to json content type

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -99,7 +99,7 @@ func JSON(w http.ResponseWriter, r *http.Request, v interface{}) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if status, ok := r.Context().Value(StatusCtxKey).(int); ok {
 		w.WriteHeader(status)
 	}


### PR DESCRIPTION
It is not mandatory, but some clients use it to detect what kind of decoding should happen. If not there they might pick the wrong decoder and break. 
the charset is added in most of the other content-types, but not in JSON