### PR TITLE
refactor: replace deprecated io/ioutil usage with io package

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/ajg/form"
@@ -40,13 +39,13 @@ func DefaultDecoder(r *http.Request, v interface{}) error {
 
 // DecodeJSON decodes a given reader into an interface using the json decoder.
 func DecodeJSON(r io.Reader, v interface{}) error {
-	defer io.Copy(ioutil.Discard, r) //nolint:errcheck
+	defer io.Copy(io.Discard, r) //nolint:errcheck
 	return json.NewDecoder(r).Decode(v)
 }
 
 // DecodeXML decodes a given reader into an interface using the xml decoder.
 func DecodeXML(r io.Reader, v interface{}) error {
-	defer io.Copy(ioutil.Discard, r) //nolint:errcheck
+	defer io.Copy(io.Discard, r) //nolint:errcheck
 	return xml.NewDecoder(r).Decode(v)
 }
 


### PR DESCRIPTION
### Description

This pull request updates the `go-chi/render` project, where the code was still using the `io/ioutil` package, which has been deprecated since `Go 1.16`. This PR updates the code to use the `io` package instead as recommended by the official Go documentation:

```> Deprecated: As of Go 1.16, the same functionality is now provided by package `io` or `os`, and those implementations should be preferred in new code.```

[io/ioutil documentation](https://pkg.go.dev/io/ioutil)

### Changes Made

- Replaced all instances of `ioutil` with the `io` package in the `decoder.go` file.
