### PR TITLE
Add HTML compatibility for DefaultResponder

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -14,6 +14,12 @@ import (
 // out to a responder. Just a short-hand.
 type M map[string]interface{}
 
+// HTMLer allows for easily represending reponses as HTML strings when accepted content
+// type is text/html
+type HTMLer interface {
+	HTML() string
+}
+
 // Respond is a package-level variable set to our default Responder. We do this
 // because it allows you to set render.Respond to another function with the
 // same function signature, while also utilizing the render.Responder() function
@@ -54,6 +60,13 @@ func DefaultResponder(w http.ResponseWriter, r *http.Request, v interface{}) {
 		JSON(w, r, v)
 	case ContentTypeXML:
 		XML(w, r, v)
+	case ContentTypeHTML:
+		htmler, ok := v.(HTMLer)
+		if ok {
+			HTML(w, r, htmler.HTML())
+			return
+		}
+		fallthrough
 	default:
 		JSON(w, r, v)
 	}


### PR DESCRIPTION
This adds HTML Accept content type compatibility into the `DefaultResponder`. Since the `HTML` function requires string input, this also adds a new `HTMLer` interface (of course can be renamed) so compatible types can be converted to HTML strings.

If an HTML content type header is detected, but the `HTMLer` interface is not supported, it uses a `fallthrough` to default to JSON responses. This helps in the case where users are relying the on the default case to render JSON when the Accept header is not set to JSON.