### PR TITLE
charset=utf-8 for JSON in responder

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -99,7 +99,7 @@ func JSON(w http.ResponseWriter, r *http.Request, v interface{}) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if status, ok := r.Context().Value(StatusCtxKey).(int); ok {
 		w.WriteHeader(status)
 	}


### PR DESCRIPTION
Hi

I added charset=utf-8 to JSON responder . All other responder have it to and this missing peace in the reponse header breaks some clients on my side. I dont see any downside to this.

kind regards