### PR TITLE
Fix: Correct documentation references from non-existent functions to actual Default functions

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -12,7 +12,7 @@ import (
 
 // Decode is a package-level variable set to our default Decoder. We do this
 // because it allows you to set render.Decode to another function with the
-// same function signature, while also utilizing the render.Decoder() function
+// same function signature, while also utilizing the DefaultDecoder function
 // itself. Effectively, allowing you to easily add your own logic to the package
 // defaults. For example, maybe you want to impose a limit on the number of
 // bytes allowed to be read from the request body.

--- a/responder.go
+++ b/responder.go
@@ -16,7 +16,7 @@ type M map[string]interface{}
 
 // Respond is a package-level variable set to our default Responder. We do this
 // because it allows you to set render.Respond to another function with the
-// same function signature, while also utilizing the render.Responder() function
+// same function signature, while also utilizing the DefaultResponder function
 // itself. Effectively, allowing you to easily add your own logic to the package
 // defaults. For example, maybe you want to test if v is an error and respond
 // differently, or log something before you respond.


### PR DESCRIPTION
Updated documentation in both responder.go and decoder.go files:
- responder.go: Changed `render.Responder()` to `DefaultResponder`
- decoder.go: Changed `render.Decoder()` to `DefaultDecoder`

This ensures accurate documentation and proper hyperlinking in Go docs for both packages.